### PR TITLE
Add format on save

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,17 @@
 'use babel';
 
-export function activate() {}
+import {CompositeDisposable} from 'atom';
+import * as formatter from './util/formatter';
+
+export function activate() {
+	this.subscriptions = new CompositeDisposable();
+
+	formatter.register(this.subscriptions);
+}
+
+export function deactivate() {
+	this.subscriptions.dispose();
+}
 
 export function provideSteelbrainLinter() {
 	const lint = require('./providers/steelbrain-linter');

--- a/lib/util/formatter.js
+++ b/lib/util/formatter.js
@@ -1,0 +1,24 @@
+'use babel';
+
+import {BufferedProcess} from 'atom';
+
+export function register(subscriptions) {
+	subscriptions.add(atom.workspace.observeTextEditors(editor => {
+		subscriptions.add(editor.onDidSave(evt => {
+			if (editor.getGrammar().scopeName !== 'source.crystal') {
+				return;
+			}
+			if (!atom.config.get('crystal.formatOnSave')) {
+				return;
+			}
+			format(evt.path);
+		}));
+	}));
+}
+
+function format(file) {
+	const command = atom.config.get('crystal.compilerExecPath');
+	const args = ['tool', 'format', file];
+
+	return new BufferedProcess({command, args});
+}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,12 @@
       "description": "The compiler command used when finding diagnostics.",
       "type": "string",
       "default": "build"
+    },
+    "formatOnSave": {
+      "title": "Format on Save",
+      "description": "Run `crystal tool format` each time a file is saved.",
+      "type": "boolean",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
Hi,

I have taken the liberty to implement basic support for code formatting. I hope this is ok. Currently I only added the option to format on save. I'm not sure if there is a need to manually trigger the formatting. Personally I don't use shortcuts or the menu for this and I actually don't see a real use case. What do you think?
