### PR TITLE
Pass env to spawn instead of setting it globally

### DIFF
--- a/lib/util/compiler.js
+++ b/lib/util/compiler.js
@@ -14,8 +14,8 @@ export function getBuildJSON(filePath) {
 		const command = atom.config.get('crystal.compilerExecPath');
 		const args = getCommandArguments(filePath);
 		createProperCrystalPath().then(path => {
-			process.env.CRYSTAL_PATH = path;
-			spawn(command, args).then(output => {
+			const env = Object.assign({}, process.env, {CRYSTAL_PATH: path});
+			spawn(command, args, {env}).then(output => {
 				resolve(output);
 			});
 		});


### PR DESCRIPTION
While working on #2 I stumbled across a strange behaviour. After every linting process `process.env.CRYSTAL_PATH` contains an additional entry to the current project path.

The problem is, that `createProperCrystalPath` always returns the current `CRYSTAL_PATH` and adds the project path to it. Now `getBuildJSON` assigns this path to `process.env.CRYSTAL_PATH` which in turn is used by `createProperCrystalPath` the next time it is invoked.

My solution is to explicitly pass the path to `spawn` instead to setting it globally.
