### PR TITLE
Refactor linter provider

### DIFF
--- a/lib/providers/steelbrain-linter.js
+++ b/lib/providers/steelbrain-linter.js
@@ -3,23 +3,39 @@
 import {getBuildJSON} from '../util/compiler';
 
 export default function lint(activeEditor) {
-	return new Promise(resolve => {
+	return new Promise((resolve, reject) => {
 		getBuildJSON(activeEditor.getPath()).then(output => {
+			if (output.length === 0) {
+				return resolve([]);
+			}
+
+			const decoder = new TextDecoder('utf-8');
 			try {
-				resolve(JSON.parse(output).map(issue => {
-					return {
-						type: 'Error',
-						text: issue.message,
-						filePath: issue.file,
-						range: [
-							[issue.line - 1, issue.column - 1],
-							[issue.line - 1, issue.column + issue.size - 1]
-						]
-					};
-				}));
+				const result = output
+					.map(data => {
+						return decoder.decode(data);
+					})
+					.map(json => {
+						return JSON.parse(json);
+					})
+					.reduce((a, b) => {
+						return a.concat(b);
+					}, [])
+					.map(issue => {
+						return {
+							type: 'Error',
+							text: issue.message,
+							filePath: issue.file,
+							range: [
+								[issue.line - 1, issue.column - 1],
+								[issue.line - 1, issue.column + issue.size - 1]
+							]
+						};
+					});
+
+				return resolve(result);
 			} catch (err) {
-				console.log(err);
-				resolve([]); // Resolve empty array when the JSON parser has issue
+				return reject(err);
 			}
 		});
 	});

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "xo": {
     "esnext": true,
     "globals": [
-      "atom"
+      "atom",
+      "TextDecoder"
     ],
     "rules": {
       "import/no-extraneous-dependencies": 0


### PR DESCRIPTION
I just found another small issue. If the linting process succeeds without error, there is an error logged to the console: `SyntaxError: Unexpected end of input`

The error is raised by `JSON.parse` after you pass it an empty array. If you pass an array of `Uint8Array`s (like in the case the compiler found errors) it works fine. That's a bit surprising to me. Is this documented behaviour?

To fix this, I restructured the code a bit.
