### PR TITLE
Fix bugs introduced in findDefaultCrystalPath

### DIFF
--- a/lib/util/compiler.js
+++ b/lib/util/compiler.js
@@ -72,8 +72,10 @@ export function findDefaultCrystalPath() {
 		});
 		command.on('close', () => {
 			const match = regex.exec(output);
-			if (!match && match.length === 2) {
+			if (match && match.length === 2) {
 				resolve(match[1]);
+			} else {
+				resolve('');
 			}
 		});
 	});


### PR DESCRIPTION
This pull request fixes issues #16 and #17. This is a regression from pull request #14. As `!match` returns `false` when there is an actual match, `resolve` will never get called and the process will hang waiting on `findDefaultCrystalPath().then(...` (results will never be delivered to linter).
This fix makes sure a proper result is returned if there is a match, or an empty string is returned if there isn't a match (for any reason).