### PR TITLE
Load package config from 'ide-crystal' instead of 'crystal' key.

### DIFF
--- a/lib/util/compiler.js
+++ b/lib/util/compiler.js
@@ -11,7 +11,7 @@ import {spawn} from './process';
 
 export function getBuildJSON(filePath) {
 	return new Promise(resolve => {
-		const command = atom.config.get('crystal.compilerExecPath');
+		const command = atom.config.get('ide-crystal.compilerExecPath');
 		const args = getCommandArguments(filePath);
 		createProperCrystalPath().then(path => {
 			const env = Object.assign({}, process.env, {CRYSTAL_PATH: path});
@@ -31,11 +31,11 @@ export function getBuildJSON(filePath) {
 
 export function getCommandArguments(filePath) {
 	const args = [];
-	args.push(atom.config.get('crystal.diagnosticsCommand'));
-	if (!atom.config.get('crystal.artifactsDuringDiagnostics')) {
+	args.push(atom.config.get('ide-crystal.diagnosticsCommand'));
+	if (!atom.config.get('ide-crystal.artifactsDuringDiagnostics')) {
 		args.push('--no-codegen');
 	}
-	if (!atom.config.get('crystal.compilerColorOutput')) {
+	if (!atom.config.get('ide-crystal.compilerColorOutput')) {
 		args.push('--no-color');
 	}
 	args.push('-f', 'json');

--- a/lib/util/formatter.js
+++ b/lib/util/formatter.js
@@ -8,7 +8,7 @@ export function register(subscriptions) {
 			if (editor.getGrammar().scopeName !== 'source.crystal') {
 				return;
 			}
-			if (!atom.config.get('crystal.formatOnSave')) {
+			if (!atom.config.get('ide-crystal.formatOnSave')) {
 				return;
 			}
 			format(evt.path);
@@ -17,7 +17,7 @@ export function register(subscriptions) {
 }
 
 function format(file) {
-	const command = atom.config.get('crystal.compilerExecPath');
+	const command = atom.config.get('ide-crystal.compilerExecPath');
 	const args = ['tool', 'format', file];
 
 	return new BufferedProcess({command, args});


### PR DESCRIPTION
Fixes #23.

The package was storing settings under the `ide-crystal` namespace but attempting to load them from `crystal`.  The result was an error since `undefined` was being passed to `spawnProcess` instead of the default of `crystal`.

This updates the config calls to all use `ide-crystal`.  Tested locally.

